### PR TITLE
Remove extraneous puts in IOObject

### DIFF
--- a/lib/adafruit/io/client/io_object.rb
+++ b/lib/adafruit/io/client/io_object.rb
@@ -27,7 +27,6 @@ module Adafruit
 
         def process_response(response)
           response = JSON.parse(response, :symbolize_names => true)
-          puts response
 
           if response.is_a?(Array)
             obj_list = []


### PR DESCRIPTION
If you use the library, it's very noisy due to printing out each response from the server.