### PR TITLE
Expose values hash instead of creating attr_list

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ group :test do
   gem 'mime-types', '< 2.0.0'
   gem 'netrc', '~> 0.7.7'
   gem 'rb-fsevent', '~> 0.9'
-  gem 'rspec', '~> 2.13.0'
+  gem 'rspec', '~> 3.4.0'
   gem 'simplecov', :require => false
   gem 'test-queue', '~> 0.1.3'
   gem 'vcr', '~> 2.4.0'

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ group :test do
   gem 'test-queue', '~> 0.1.3'
   gem 'vcr', '~> 2.4.0'
   gem 'webmock', '~> 1.9.0'
+  gem 'dotenv', '~> 2.1.1'
 end
 
 platforms :rbx do

--- a/lib/adafruit/io/client/data.rb
+++ b/lib/adafruit/io/client/data.rb
@@ -5,11 +5,9 @@ module Adafruit
   module IO
     class Data < IOObject
       def initialize(client = nil, feed = nil, id_or_key = nil)
-        @client = client
+        super(client, id_or_key)
+
         @feed = feed
-        @id_or_key = id_or_key
-        @unsaved_values = Set.new
-        @values = {}
         @base_url = "feeds/#{@feed.id_or_key}"
       end
 

--- a/lib/adafruit/io/client/feed.rb
+++ b/lib/adafruit/io/client/feed.rb
@@ -5,13 +5,8 @@ module Adafruit
   module IO
 
     class Feed < IOObject
-      attr_accessor :unsaved_values, :id_or_key
-
       def initialize(client = nil, id_or_key = nil)
-        @client = client
-        @id_or_key = id_or_key
-        @unsaved_values = Set.new
-        @values = {}
+        super(client, id_or_key)
       end
 
       def create(options = {})       

--- a/lib/adafruit/io/client/group.rb
+++ b/lib/adafruit/io/client/group.rb
@@ -4,10 +4,7 @@ module Adafruit
   module IO
     class Group < IOObject
       def initialize(client = nil, id_or_key = nil)
-        @client = client
-        @id_or_key = id_or_key
-        @unsaved_values = Set.new
-        @values = {}
+        super(client, id_or_key)
       end
 
       def create(options = {})       

--- a/lib/adafruit/io/client/io_object.rb
+++ b/lib/adafruit/io/client/io_object.rb
@@ -7,7 +7,7 @@ require 'active_support/core_ext/object/instance_variables'
 module Adafruit
   module IO
     class IOObject
-      attr_accessor :unsaved_values, :id_or_key
+      attr_accessor :unsaved_values, :id_or_key, :values
 
       def initialize(client = nil, id_or_key = nil)
         @client = client

--- a/lib/adafruit/io/client/io_object.rb
+++ b/lib/adafruit/io/client/io_object.rb
@@ -7,6 +7,14 @@ require 'active_support/core_ext/object/instance_variables'
 module Adafruit
   module IO
     class IOObject
+      attr_accessor :unsaved_values, :id_or_key
+
+      def initialize(client = nil, id_or_key = nil)
+        @client = client
+        @id_or_key = id_or_key
+        @unsaved_values = Set.new
+        @values = {}
+      end
 
       protected
         #serialize_params derived from stripe-ruby library, MIT License, Copyright (c) 2011- Stripe, Inc. (https://stripe.com)

--- a/spec/README.md
+++ b/spec/README.md
@@ -1,0 +1,31 @@
+# Adafruit IO Ruby Client Test README
+
+To run the tests you can use rake from the top level directory, as follows:
+
+    rake test
+
+Most tests require a valid Adafruit IO account to run, and they key for this
+account is provided in the ADAFRUIT_API_KEY environment variable.  Make sure to
+set this envirionment variable before running the tests, for example to run all
+the tests with a key execute in this directory:
+
+    ADAFRUIT_IO_KEY=my_key rake test
+
+Alternatively, you can place the key into a file in the top level directory
+called _.env_.  The format is the same as above, but as a single line and
+by itself. e.g.
+
+    ADAFRUIT_IO_KEY=my_key
+
+# NOTES
+
+- Take care running the tests that you do not spam the server.  There are
+server throttle checks and if you exceed the limit, you will be blocked for
+a period of time. See
+[HTTP 503: Unavailable](https://learn.adafruit.com/adafruit-io/http-status-codes).
+See also [Data Policies](https://learn.adafruit.com/adafruit-io/data-policies).
+
+- Additionally, you must have one feed, one group and one dashboard available
+for creating. (As of this writing, you are allowed only 10, 10, and 5,
+respectively). Again see
+[Data Policies](https://learn.adafruit.com/adafruit-io/data-policies)

--- a/spec/README.md
+++ b/spec/README.md
@@ -1,13 +1,12 @@
 # Adafruit IO Ruby Client Test README
 
-To run the tests you can use rake from the top level directory, as follows:
+To run the tests you can use rake from the top level directory.
 
-    rake test
+However, most tests require a valid Adafruit IO account to run, and so an
+account key needs to be provided.  The key is passed to the tests via an
+environment variable called ADAFRUIT_IO_KEY.
 
-Most tests require a valid Adafruit IO account to run, and they key for this
-account is provided in the ADAFRUIT_API_KEY environment variable.  Make sure to
-set this envirionment variable before running the tests, for example to run all
-the tests with a key execute in this directory:
+So, the tests can be run via the following command:
 
     ADAFRUIT_IO_KEY=my_key rake test
 
@@ -15,12 +14,13 @@ Alternatively, you can place the key into a file in the top level directory
 called _.env_.  The format is the same as above, but as a single line and
 by itself. e.g.
 
+    # cat .env
     ADAFRUIT_IO_KEY=my_key
 
 # NOTES
 
-- Take care running the tests that you do not spam the server.  There are
-server throttle checks and if you exceed the limit, you will be blocked for
+- Take care running the tests that you do not spam the server.  The server has
+throttle checks in place and if you exceed the limit, you will be blocked for
 a period of time. See
 [HTTP 503: Unavailable](https://learn.adafruit.com/adafruit-io/http-status-codes).
 See also [Data Policies](https://learn.adafruit.com/adafruit-io/data-policies).

--- a/spec/adafruit/io/feed_spec.rb
+++ b/spec/adafruit/io/feed_spec.rb
@@ -1,0 +1,126 @@
+require 'helper'
+
+# List of current properties associated with a feed.
+FEED_PROPS_v1_0_2 = %w(
+  id          key         name        description
+  unit_symbol unit_type   last_value
+  visibility  status      enabled
+  created_at  updated_at  history     license
+)
+
+RSpec.describe Adafruit::IO::Feed do
+  context 'starting with no feeds' do
+    context '#retrieve with one argument' do
+      it 'returns an error' do
+        feed = $aio.feeds.retrieve FEED_NAME1
+
+        ##TODO: really dislike this error check - it should raise an
+        #       exception or have an error property or return (error, feed)
+        #       or something similar
+        #       (maybe config choice: raise or not as well)
+
+        expect(feed).to respond_to :error
+      end
+    end
+
+    ##TODO: need a test account to test with no feeds whatsoever
+
+    context '#create' do
+      it 'returns a new feed with the expected properties' do
+        props = {}
+        props['name'] = FEED_NAME1
+        feed = $aio.feeds.create(props)
+
+        expect(feed).not_to         respond_to :error
+        expect(feed.name).to        eq FEED_NAME1
+        expect(feed.values.keys.sort).to eq FEED_PROPS_v1_0_2.sort
+      end
+    end
+  end
+
+  context 'with a newly created feed,' do
+    context '#retrieve, with no args' do
+      it 'returns several feeds, with one containing the newly created feed' do
+        feeds = $aio.feeds.retrieve
+
+        feed = feeds.find { |f| f.name == FEED_NAME1 }
+
+        expect(feed).not_to   be_nil
+        expect(feed.name).to  eq FEED_NAME1
+      end
+    end
+
+    context '#retrieve, with one arg' do
+      it 'returns that feed' do
+        feed = $aio.feeds.retrieve FEED_NAME1
+
+        expect(feed.name).to eq FEED_NAME1
+      end
+    end
+
+    describe '#save' do
+      before(:example) do
+        @feed = $aio.feeds.retrieve(FEED_NAME1)
+      end
+
+      it 'returns that feed' do
+        expect(@feed.name).to         eq FEED_NAME1
+        expect(@feed.description).to  be_nil
+      end
+
+      context 'updating the description' do
+        it 'is returns the same feed' do
+          @feed.description = FEED_DESC
+          f = @feed.save
+
+          expect(f.id).to eq @feed.id
+        end
+
+        it 'has the changed description' do
+          expect(@feed.description).to eq FEED_DESC
+        end
+      end
+    end
+
+    context '#data, from a feed with no data' do
+      it 'with no arguments, returns an object with no values' do
+        feed = $aio.feeds.retrieve FEED_NAME1
+        data = feed.data
+
+        expect(data.values).to    eq({})
+      end
+
+      it 'with one argument, returns an object with no values' do
+        feed = $aio.feeds.retrieve FEED_NAME1
+        data = feed.data DATA_NAME1
+
+        expect(data.values).to     eq({})
+      end
+    end
+
+    context '#delete' do
+      ## TODO: need to split this into two separate tests, but we need
+      ## TODO:  the feed variable to stay in scope for both 'it' blocks
+      it 'returns that feed and cannot be deleted again' do
+        feed = $aio.feeds.retrieve FEED_NAME1
+        expect(feed.name).to eq FEED_NAME1
+        feed_id = feed.id
+
+        result = feed.delete
+        expect(result['delete']).to eq(true)
+        expect(result['id']).to     eq feed_id
+
+        result = feed.delete
+        expect(result['delete']).to eq(false)
+      end
+
+      context '#retrieve for that feed' do
+        it 'now returns an error' do
+          feed = $aio.feeds.retrieve(FEED_NAME1)
+
+          expect(feed).to respond_to(:error)
+        end
+      end
+    end
+  end
+end

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -13,6 +13,8 @@ WebMock.disable_net_connect!(allow: 'io.adafruit.com')
 Dotenv.load
 
 MY_KEY    = ENV['ADAFRUIT_IO_KEY'].freeze
+MY_KEY.nil? || MY_KEY.empty? and
+      ($stderr.puts("No Key Found - cannot continue.") ; exit(1))
 
 # NOTE: we should test with multiple feeds, but there's only 10 allowed
 #       and so limiting to one.

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -1,4 +1,45 @@
 require 'json'
-require 'adafruit/io'
 require 'rspec'
+require 'dotenv'
 require 'webmock/rspec'
+
+require 'simplecov'
+SimpleCov.start
+
+require 'adafruit/io'
+
+WebMock.disable_net_connect!(allow: 'io.adafruit.com')
+
+Dotenv.load
+
+MY_KEY    = ENV['ADAFRUIT_API_KEY'].freeze
+
+# NOTE: we should test with multiple feeds, but there's only 10 allowed
+#       and so limiting to one.
+#       ##TODO investigate making/getting a test account of some kind
+FEED_NAME1 = 'test_feed_1'.freeze
+FEED_DESC = 'My Test Feed Description'.freeze
+
+DATA_NAME1 = 'test_data_1'.freeze
+DATA_NAME2 = 'test_data_2'.freeze
+
+GROUP_NAME1 = 'test_group_1'.freeze
+GROUP_NAME2 = 'test_group_2'.freeze
+
+DASHBOARD_NAME1 = 'test_dashboard_1'.freeze
+DASHBOARD_NAME2 = 'test_dashboard_2'.freeze
+
+$aio = nil
+
+RSpec.describe 'initialization' do
+  context 'starting with no feeds' do
+    it 'found an API key in the environment' do
+      expect(MY_KEY).to be_a String
+    end
+
+    it 'can create a client using that key' do
+      $aio = Adafruit::IO::Client.new key: MY_KEY
+      expect($aio).to_not be_nil
+    end
+  end
+end

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -12,7 +12,7 @@ WebMock.disable_net_connect!(allow: 'io.adafruit.com')
 
 Dotenv.load
 
-MY_KEY    = ENV['ADAFRUIT_API_KEY'].freeze
+MY_KEY    = ENV['ADAFRUIT_IO_KEY'].freeze
 
 # NOTE: we should test with multiple feeds, but there's only 10 allowed
 #       and so limiting to one.
@@ -33,7 +33,7 @@ $aio = nil
 
 RSpec.describe 'initialization' do
   context 'starting with no feeds' do
-    it 'found an API key in the environment' do
+    it 'found an IO key in the environment' do
       expect(MY_KEY).to be_a String
     end
 


### PR DESCRIPTION
This is what I'm preferring to pull #6 

It still moves the common attributes to IOObject, and then just exposes the values hash.

Cleaner and less redundancy.

Still have redundant access to the properties, but that seems fine.