### PR TITLE
Manual tests (only)

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,3 +5,17 @@ RSpec::Core::RakeTask.new(:spec)
 
 task :test => :spec
 task :default => :spec
+
+require 'rake/testtask'
+
+Rake::TestTask.new do |t|
+  t.name = "iolib"
+  t.test_files = FileList[ 'manual_tests/test_iolib.rb' ]
+  t.verbose = true
+end
+
+Rake::TestTask.new do |t|
+  t.name = "http"
+  t.test_files = FileList[ 'manual_tests/test_http.rb' ]
+  t.verbose = true
+end

--- a/manual_tests/README.md
+++ b/manual_tests/README.md
@@ -10,7 +10,7 @@ environment variable called ADAFRUIT_IO_KEY.
 
 So, the base tests can be run via the following command:
 
-    ADAFRUIT_IO_KEY=my_key rake test iolib
+    ADAFRUIT_IO_KEY=my_key rake iolib
 
 Alternatively, you can place the key into a file in the top level directory
 called _.env_.  The format is the same as above, but as a single line and
@@ -29,6 +29,11 @@ is tested and covered.)
 There is another test that can be run, which uses HTTP to access the server,
 instead of the _io-client-ruby_ library.  This test can be run, for instance,
 determine if a failure lies within the ruby library itself.
+
+The HTTP tests can be run via the following rake command (assuming the key
+is already specified somehow):
+
+    rake http
 
 Both tests run the exact same tests and verification and share much code - it
 is only the mechanism of hitting the server that differs, so the HTTP-based

--- a/manual_tests/README.md
+++ b/manual_tests/README.md
@@ -1,0 +1,49 @@
+# Adafruit IO Ruby Manual Test README
+
+To run the tests you can use rake from the top level directory.
+
+However, these tests require a valid Adafruit IO account to run, and so an
+account key needs to be provided.  The key is passed to the tests via an
+environment variable called ADAFRUIT_IO_KEY.
+
+## Ruby library based test
+
+So, the base tests can be run via the following command:
+
+    ADAFRUIT_IO_KEY=my_key rake test iolib
+
+Alternatively, you can place the key into a file in the top level directory
+called _.env_.  The format is the same as above, but as a single line and
+by itself. e.g.
+
+    # cat .env
+    ADAFRUIT_IO_KEY=my_key
+
+The default tests run through the library code and provide essentially
+100% code coverage. (There is currently an exception or two that need
+addressing, but those are corner cases.  100% of the server functionality
+is tested and covered.)
+
+## Direct HTTP-based test
+
+There is another test that can be run, which uses HTTP to access the server,
+instead of the _io-client-ruby_ library.  This test can be run, for instance,
+determine if a failure lies within the ruby library itself.
+
+Both tests run the exact same tests and verification and share much code - it
+is only the mechanism of hitting the server that differs, so the HTTP-based
+tests are a reliable way of verifying server changes.  And so, it can be used
+periodically, or whenever there are server side changes to the API as well.
+
+
+# NOTES
+
+- Take care running the tests that you do not spam the server.  The server has
+throttle checks in place and if you exceed the limit, you will be blocked for
+a period of time. See
+[HTTP 503: Unavailable](https://learn.adafruit.com/adafruit-io/http-status-codes).
+See also [Data Policies](https://learn.adafruit.com/adafruit-io/data-policies).
+
+- Additionally, you must have one feed and one group slot open for creation.
+(As of this writing, you are allowed only 10 feeds and 10 groups).
+Again see [Data Policies](https://learn.adafruit.com/adafruit-io/data-policies)

--- a/manual_tests/lib/common.rb
+++ b/manual_tests/lib/common.rb
@@ -1,0 +1,12 @@
+$LOAD_PATH.unshift(File.dirname(__FILE__))
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
+
+# There's only 10 feeds/groups allowed and so limiting testing to one.
+FEED_NAME1 = 'test_feed_1'.freeze
+FEED_DESC = 'My Test Feed Description'.freeze
+
+DATA_NAME1 = 'test_data_1'.freeze
+DATA_NAME2 = 'test_data_2'.freeze
+
+GROUP_NAME1 = 'test_group_1'.freeze
+GROUP_NAME2 = 'test_group_2'.freeze

--- a/manual_tests/lib/httpdirectfetch.rb
+++ b/manual_tests/lib/httpdirectfetch.rb
@@ -1,0 +1,326 @@
+#!/usr/bin/env ruby
+
+# Special case return data / cases -- using constants to call out/document them
+# - The framework expects consistent returns namely [ success_bool, JSON ]
+#   where the JSON is data or { error: error_description_string }
+GET_NONEXIST_DATA_RETURNS_JSON  = true
+GET_NONEXIST_GROUP_RETURNS_JSON = true
+DELETE_RETURNS_NOTHING          = true
+
+require 'faraday'
+require 'faraday_middleware'          # for c.request :json
+require 'json'
+
+require 'dotenv'
+Dotenv.load
+
+ADAFRUIT_IO_KEY = ENV['ADAFRUIT_IO_KEY'].freeze
+ADAFRUIT_IO_KEY.nil? || ADAFRUIT_IO_KEY.empty? and
+                                      ( $stderr.puts("No Key Found") ; exit(1))
+
+require 'common'
+require 'verify'
+require 'testobject'
+
+# https://io.adafruit.com/api/docs
+
+BaseURL     = "https://io.adafruit.com/api"   # /feeds.csv, /feeds/1.xml, etc.
+APIVersion  = "1.1.0"
+
+#-------------------------------------------------------------------------------
+
+# Module for accessing https://Adafruit.io via its HTTP REST API
+
+module HTTPDirectFetch
+
+  ##
+  # Handle an error condition
+  #
+  # @return an error description string
+  def handle_error(status, body)
+
+    if status == 401 || status == 403    # Unauthorized
+      $stderr.puts "\nInvalid Key -- cannot continue, exiting... (#{status})\n\n"
+      exit(status)
+    end
+
+    if status == 500 && ERROR_500_NOT_JSON
+      # Comes back as plain text
+      body = "{ \"error\"   : \"#{body.lines[0].join('; ')}\" }"
+    end
+
+    begin
+      json = JSON.parse(body, :symbolize_names => true)
+    rescue => e
+      $stderr.puts "==============\nbody: "
+      ap body
+      $stderr.puts "exception: "
+      ap e
+      $stderr.puts "==============\n\n"
+      raise
+    end
+
+    json[:error] = "Unspecified error" unless json.has_key? :error
+
+    @error = json[:error]
+    return json
+  end
+
+  ##
+  # Invoke the HTTP request and return the response
+  #
+  def _invoke(op, url_path, payload = nil)
+
+    @@conn ||= Faraday.new(:url => BaseURL) do |c|
+        c.headers['X-AIO-Key'] = ADAFRUIT_IO_KEY
+        c.headers['Accept'] = 'application/json'
+        c.request :json
+        c.adapter Faraday.default_adapter
+    end
+
+    response = @@conn.send(op) do |req|
+      req.url URI::encode(url_path)
+      req.body = JSON.dump(payload) if payload
+    end
+
+    response
+  end
+
+  #-----------------------------------------------------------------------------
+  ##
+  # The framework expects consistent return values, so handle them here
+  # Handle return of empty JSON
+  #
+  # @return [ bool, JSON_str ] ; bool indicates success
+  #         if false (error case), JSON_str is { error: error_str } as a string
+  #         (called before converting response.body, so JSON str)
+  def handle_empty_body(response, op, url_path)
+
+    # Deleting something returns nothing - http code indicates success
+    if op == :delete && DELETE_RETURNS_NOTHING
+      body = "{ \"deleted\" : \"#{response.success?}\" }"
+      return [ response.status, body ]
+    end
+
+    body = "{ \"error\" : \"empty body\" }"
+    return [ 400, body ]
+  end
+
+  #-----------------------------------------------------------------------------
+  ##
+  # The framework expects consistent return values, so handle them here
+  # Handle other special cases
+  #
+  # @return [ bool, JSON_obj ] ; bool indicates success
+  #         if false (error case), JSON_obj is { error: error_str }
+  #         (called after converting response.body, so JSON object)
+  def is_special_case(response, op, url_path, json)
+
+    # If the data item doesn't exist, it returns
+    #       { }
+    if op == :get && GET_NONEXIST_DATA_RETURNS_JSON && url_path =~ /feed/
+      return nil unless json.is_a?(Hash)
+
+      if json.empty? || (json.has_key?(:error) && json[:error] =~ /not found/)
+        @error = { error: "ENOEXIST" }
+        return [ false, @error ]
+      end
+    end
+
+    # If the group doesn't exist, it returns
+    #       { :feeds => { :last_stream => {} } }
+    # instead of
+    #       404 Not Found (or ala Feed: empty JSON)
+    #
+    if op == :get && GET_NONEXIST_GROUP_RETURNS_JSON && url_path =~ /group/
+      return nil unless json.is_a?(Hash)
+
+      unless json.has_key?(:name)
+        @error = { error: "ENOEXIST" }
+        return [ false, @error ]
+      end
+      return nil
+    end
+
+    return nil
+  end
+
+  #-----------------------------------------------------------------------------
+  ##
+  # Common method for invoking an HTTP REST call
+  #
+  # @param op         The HTTP verb (i.e. get, post, put, patch, delete)
+  # @param url_path   The path to the resource (e.g. /api/feeds/)
+  # @param payload    Only required if verb calls for it.
+  #
+  # @return [ http_status_code: Integer, json: JSON ]
+  # if http_status_code indicates and error, the json will be the error string
+  #
+  def invoke(op, url_path, payload = nil)
+    response = _invoke(op, url_path, payload)
+
+    body = response.body
+    status = response.status
+
+    if body.empty?
+      status, body = handle_empty_body(response, op, url_path)
+    end
+
+    unless status < 400
+      err_json = handle_error(status, body)        # can throw
+
+      return [ false, err_json ]
+    end
+
+    begin
+      json = JSON.parse(body, :symbolize_names => true)
+    rescue => e
+      $stderr.puts "==============\nbody: "
+      ap response.body
+      $stderr.puts "exception: "
+      ap e
+      $stderr.puts "==============\n\n"
+      raise
+    end
+
+    ret = is_special_case(response, op, url_path, json)
+    return ret unless ret.nil?
+
+    [ true, json ]
+  end
+
+  # Convenience method to get an object or get all objects
+  #
+  # @returns [ success?, json_body ]
+  def base_get(url_path)                                # GET
+    invoke(:get, url_path)
+  end
+
+  # Convenience method to create an object
+  #
+  # @returns [ success?, json_body ]
+  def base_post(url_path, payload)                      # POST
+    invoke(:post, url_path, payload)
+  end
+
+  # Convenience method to delete an object
+  #
+  # @returns [ success?, json_body ]
+  def base_delete(url_path)                             # DELETE
+    invoke(:delete, url_path)
+  end
+
+  # Convenience method to update (patch) properties of an object
+  #
+  # @returns [ success?, json_body ]
+  def base_patch(url_path, payload)                     # PATCH
+    invoke(:patch, url_path, payload)
+  end
+
+  # Convenience method to replace an entire object
+  #
+  # @returns [ success?, json_body ]
+  def base_put(url_path, payload)                       # PUT
+    invoke(:put, url_path, payload)
+  end
+
+  # Create an object outside the tests - used to init the starting case
+  #
+  # @returns [ success?, json_body ]
+  def non_test_get(url_path)                                # GET
+    invoke(:get, url_path)
+  end
+
+  # Delete an object outside the tests - used to init the starting case
+  #
+  # @returns [ success?, json_body ]
+  def non_test_delete(url_path)                             # DELETE
+    invoke(:delete, url_path)
+  end
+
+  #-----------------------------------------------------------------------------
+  ##
+  # Methods called by the testing framework (TestObject)
+  #
+  def do_test_create()
+    base_post("#{@obj_path}/", @prop_sets[:create])
+  end
+
+  def do_test_get_all()
+    base_get("#{@obj_path}/")
+  end
+
+  def do_test_get_one(id)
+    base_get("#{@obj_path}/#{id}")
+  end
+
+  def do_test_update()
+    base_patch("#{@obj_path}/#{@created_id}", @prop_sets[:update])
+  end
+
+  def do_test_replace()
+    base_put("#{@obj_path}/#{@created_id}", @prop_sets[:replace])
+  end
+
+  def do_test_delete()
+    base_delete("#{@obj_path}/#{@created_id}")
+  end
+
+  #-----------------------------------------------------------------------------
+  ##
+  # Code coverage not applicable
+  def do_test_code_coverage_feed
+  end
+
+  def do_test_code_coverage_group
+  end
+
+  def do_test_code_coverage_data
+  end
+
+  #-----------------------------------------------------------------------------
+  ##
+  # Ensure a clean starting state
+  #  - queries and deletes all objects that we create
+  def ensure_starting_state()
+
+    delete_all = ->(path, names) do
+      ok, all_objs = non_test_get("#{path}")
+      return unless ok
+
+      all_objs.each do |obj|
+        obj_name = get_prop(obj, :name)
+        next unless names.any? { |n| n == obj_name }
+
+        id = get_prop(obj, :id)
+        return if id.nil?
+
+        ok, all_objs = non_test_delete("#{path}/#{id}")
+      end
+    end
+
+    delete_all.call("feeds",  TEST_FEED_NAMES)
+    delete_all.call("groups", TEST_GROUP_NAMES)
+  end
+
+  #-----------------------------------------------------------------------------
+  ##
+  # Data tests require a feed, so these methods create/delete feeds without
+  #   going through the standard feed test path.
+  def non_test_create_data_feed()
+    ok, feed = invoke(:post, "feeds/", @payload)
+
+    unless ok        # Intentionally avoiding PASS message
+      $stderr.puts "create test data feed #{@payload[:name]} -> #{ok}"
+      return
+    end
+
+    @feed_id = get_prop(feed, :id).to_s
+    @obj_path.sub!("_FEEDID_", @feed_id)
+  end
+
+  def non_test_delete_data_feed()
+    ok, _ = invoke(:delete, "feeds/#{@feed_id}")
+    $stderr.puts "delete test data feed #{@payload[:name]} -> #{ok}" unless ok
+  end
+end

--- a/manual_tests/lib/rubylibfetch.rb
+++ b/manual_tests/lib/rubylibfetch.rb
@@ -1,0 +1,263 @@
+#!/usr/bin/env ruby
+
+# Special case return data / cases -- using constants to call out/document them
+# - The framework expects consistent returns namely [ success_bool, JSON ]
+#   where the JSON is data or { error: error_description_string }
+GET_NONEXIST_DATA_RETURNS_JSON  = true
+GET_NONEXIST_GROUP_RETURNS_JUNK = true
+
+require 'dotenv'
+Dotenv.load
+
+ADAFRUIT_IO_KEY = ENV['ADAFRUIT_IO_KEY'].freeze
+ADAFRUIT_IO_KEY.nil? || ADAFRUIT_IO_KEY.empty? and
+                                      ( $stderr.puts("No Key Found") ; exit(1))
+
+require 'common'
+require 'verify'
+require 'testobject'
+
+require 'simplecov'
+SimpleCov.start
+SimpleCov.command_name "test:library"
+
+require 'adafruit/io'
+
+AIO = Adafruit::IO::Client.new :key => ENV['ADAFRUIT_IO_KEY'].freeze
+
+#-------------------------------------------------------------------------------
+# Module for accessing https://Adafruit.io via its ruby library
+
+module RubyLibFetch
+
+  #-----------------------------------------------------------------------------
+  ##
+  # The framework expects consistent return values, so handle them here
+  # Handle sucess special cases
+  #
+  # @return [ bool, JSON_obj ] ; bool indicates success
+  #         if false (error case), JSON_obj is { error: error_str }
+  #         (called after converting response.body, so JSON object)
+  def is_special_case_success(obj)
+    return nil if obj.is_a?(Array)
+
+    # If the group doesn't exist, it returns
+    #       { :feeds => { :last_stream => {} } }
+    # instead of
+    #       404 Not Found
+    #
+    if GET_NONEXIST_GROUP_RETURNS_JUNK && @obj_name == "groups"
+      unless obj.respond_to?(:name)
+        @error = { error: "ENOEXIST" }
+        return [ false, obj ]
+      end
+
+      return nil
+    end
+
+    # If the data item doesn't exist, it returns
+    #       { }
+    if GET_NONEXIST_DATA_RETURNS_JSON && @obj_name == "data"
+      unless obj.respond_to?(:value)
+        @error = { error: "ENOEXIST" }
+        return [ false, obj ]
+      end
+
+      return nil
+    end
+
+    return nil
+  end
+
+  def process_result(obj)
+
+    if obj.respond_to?(:error)
+      @error = obj.error
+      return [ false, obj.error ]
+    end
+
+    ret = is_special_case_success(obj)
+    return ret unless ret.nil?
+
+    [ true, obj ]
+  end
+
+  def process_del_result(obj, id)
+    ok = (obj == {"delete" => true, "id" => id })
+    @error = obj unless ok
+    [ ok, nil ]
+  end
+
+  #=============================================================================
+  ##
+  # Methods called by the testing framework (TestObject)
+  #
+  def do_test_create()
+    case @obj_name
+    when "feeds"
+      return process_result(AIO.feeds.create(@prop_sets[:create]))
+    when "groups"
+      return process_result(AIO.groups.create(@prop_sets[:create]))
+    when "data"
+      return process_result(@feed.data.create(@prop_sets[:create]))
+    end
+
+    $stderr.puts "Unknown object: #{@obj_name}"
+    [ false, { error: "ENOIMPL" } ]
+  end
+
+  def do_test_get_all()
+    case @obj_name
+    when "feeds"
+      return process_result(AIO.feeds.retrieve)
+    when "groups"
+      return process_result(AIO.groups.retrieve)
+    when "data"
+      return process_result(@feed.data.retrieve)
+    end
+
+    $stderr.puts "Unknown object: #{@obj_name}"
+    [ false, { error: "ENOIMPL" } ]
+  end
+
+  def do_test_get_one(id_key_name)
+    case @obj_name
+    when "feeds"
+      return process_result(AIO.feeds.retrieve(id_key_name))
+    when "groups"
+      return process_result(AIO.groups.retrieve(id_key_name))
+    when "data"
+      return process_result(@feed.data.retrieve(id_key_name))
+    end
+
+    $stderr.puts "Unknown object: #{@obj_name}"
+    [ false, { error: "ENOIMPL" } ]
+  end
+
+  def do_test_update()
+    @error = "Library API doesn't support REST PATCH verb"
+    # NOTE: the library acts more like a PATCH (update) than a PUT (replace)
+    return [ nil, @test_obj ]
+
+#    @prop_sets[:update].each { |k, v| @test_obj.send(k, v) }
+#
+#    case @obj_name
+#    when "feeds"
+#      return process_result(AIO.feeds.save)
+#    when "groups"
+#      return process_result(AIO.groups.save)
+#    when "data"
+#      return process_result(@feed.data.save)
+#    end
+#    $stderr.puts "Unknown object: #{@obj_name}"
+#    [ false, { error: "ENOIMPL" } ]
+  end
+
+  def do_test_replace()
+    # NOTE: the library acts more like a PATCH (update) than a PUT (replace)
+
+    @prop_sets[:replace].each { |k, v| @test_obj.send("#{k}=".to_s, v) }
+
+    case @obj_name
+    when "feeds"
+      return process_result(@test_obj.save)
+    when "groups"
+      return process_result(@test_obj.save)
+    when "data"
+      return process_result(@test_obj.save)
+    end
+
+    $stderr.puts "Unknown object: #{@obj_name}"
+    [ false, { error: "ENOIMPL" } ]
+  end
+
+  def do_test_delete()
+    id = @test_obj.id
+
+    case @obj_name
+    when "feeds"
+      return process_del_result(@test_obj.delete, id)
+    when "groups"
+      return process_del_result(@test_obj.delete, id)
+    when "data"
+      return process_del_result(@test_obj.delete, id)
+    end
+
+    $stderr.puts "Unknown object: #{@obj_name}"
+    [ false, { error: "ENOIMPL" } ]
+  end
+
+  def do_test_code_coverage_feed
+    ok, _obj = process_result(AIO.feeds.retrieve(24601))
+    expect("Invalid feed") { !ok }
+  end
+
+  def do_test_code_coverage_group
+    ok, _obj = process_result(AIO.groups.retrieve(24601))
+    expect("Invalid group") { !ok }
+
+    ## NOTE: there are others, but they are all undocumented in
+    #         https://io.adafruit.com/api/docs/#!/Groups/all
+    #         (and many are broken) -- 160616
+  end
+
+  def do_test_code_coverage_data
+    prev =  @prop_sets[:replace]["value"]
+
+    ok, obj = process_result(@feed.data.create({ "value" => "foo" }))
+    expect("Data#create") { ok && obj.respond_to?(:value) && obj.value == "foo" }
+
+    ok, obj = process_result(@feed.data.last)
+    expect("Data#last") { ok && obj.respond_to?(:value) && obj.value == "foo" }
+
+    ok, obj = process_result(@feed.data.previous)
+    expect("Data#previous") { ok && obj.respond_to?(:value) && obj.value == "foo" }
+
+    ok, obj = process_result(@feed.data.next)
+    expect("Data#next") { ok && obj.respond_to?(:value) && obj.value == prev }
+
+    ##TODO: needs library fixes
+    #ok, obj = process_result(AIO.feeds("test_feed2").data.send_data("24601"))
+    #expect("Data#send_data") { ok && obj.respond_to?(:value) && obj.value == "24601" }
+  end
+
+  #-----------------------------------------------------------------------------
+  ##
+  # Ensure a clean starting state
+  #  - queries and deletes all objects that we create
+  def ensure_starting_state()
+
+    delete_all = ->(path, names) do
+      all_objs = AIO.send(path).retrieve
+      return unless all_objs.is_a? Array
+
+      all_objs.each do |obj|
+        obj_name = obj.name
+        next unless names.any? { |n| n == obj_name }
+
+        h = obj.delete
+        _ok = h.is_a?(Hash) && h["delete"]
+      end
+    end
+
+    delete_all.call(:feeds,  TEST_FEED_NAMES)
+    delete_all.call(:groups, TEST_GROUP_NAMES)
+  end
+
+  #-----------------------------------------------------------------------------
+  ##
+  # Data tests require a feed, so these methods create/delete feeds without
+  #   going through the standard feed test path.
+  def non_test_create_data_feed()
+    @feed = AIO.feeds.create(@payload)
+    @feed_id = @feed.id.to_s
+    @obj_path.sub!("_FEEDID_", @feed_id)
+    $stderr.puts "create test data feed #{@payload[:name]} -> #{!@feed.respond_to?(:error)}"
+  end
+
+  def non_test_delete_data_feed()
+    h = @feed.delete
+    ok = h["delete"]
+    $stderr.puts "delete test data feed #{@payload[:name]} -> #{ok}" unless ok
+  end
+end

--- a/manual_tests/lib/testobject.rb
+++ b/manual_tests/lib/testobject.rb
@@ -1,0 +1,326 @@
+#!/usr/bin/env ruby
+
+##
+# Framework for testing the Adafruit IO remote API
+#
+#  It can test either the HTTP REST API (via Faraday HTTP gem) or the ruby
+#     API library interface.
+#
+#  Only tests the basics of the API - i.e. that each is minimally available
+#  For example, it
+#   - does not extensively test setting properties of an object
+#   - does not test various formats - just JSON
+#   - does not test multiple objects - e.g. just that find all returns an array
+#
+#   The tests covers API version 1.1.1
+#   The tests will provide 100% code coverage.
+#     The tests cover all API of Feed and Group.
+#     The tests cover all of Data, except:          (as of 160612) TODO
+#
+#  GET     => "/feeds/f_idkn/data/receive",  # Receive data?
+#  GET     => "/feeds/f_idkn/data/previous", # Previous Data in Queue
+#  GET     => "/feeds/f_idkn/data/next",     # Next     Data in Queue
+#  GET     => "/feeds/f_idkn/data/last",     # Last     Data in Queue
+#
+#  POST    => "/feeds/f_idkn/data",          # Create new data item
+#  POST    => "/feeds/f_idkn/data/send",     # Create new feed AND data item
+
+require "testobjectdata"
+
+##
+# TestObject for testing a Feed or a Group
+#
+class TestObject
+  include Verify
+
+  ##
+  # Create a test object for a specific object or no object
+  #
+  # @param prop_sets  if nil, then TestObject's purpose is to ensure a clean
+  #                     starting state.  Otherwise, it is a hash that specifies
+  #                     the object specifics (i.e. the feed/group/data object
+  #                     properties)
+  def initialize(prop_sets = nil)
+    return if prop_sets.nil?                      ## TODO move ensure* to another class
+
+    @obj_name     = prop_sets[:name]
+    @obj_path     = prop_sets[:path]
+    @prop_sets    = prop_sets
+
+    @created_id   = nil
+    @created_obj  = nil
+    @test_obj     = nil
+
+    @test_name    = nil
+    @error        = nil
+  end
+
+  ##
+  #
+  # Run the entire suite - expects a clean state
+  # (i.e. no existing test feed or group)
+  def run()
+    if @created_obj.nil?
+      return if test_create().nil?
+    end
+
+    test_get_all
+    test_key_id_name
+    test_update
+    test_replace
+
+    case @obj_name
+    when 'feeds'  then test_code_coverage_feed
+    when 'groups' then test_code_coverage_group
+    when 'data'   then test_code_coverage_data
+    else puts "Unknown object '@obj_name' for code coverage - ignoring.."
+    end
+
+    test_delete
+    test_deleted
+
+    puts "- #{@obj_name} DONE"
+  end
+
+  #-----------------------------------------------------------------------------
+  ##
+  # Test 1 - Create a feed/group/data item
+  def test_create()
+    @test_name = "test_#{@obj_name}: create:      "
+    @error     = nil
+
+    ok, obj = do_test_create
+    return nil if expect("") { ok }
+
+    @test_obj = obj
+    if verify_against(@prop_sets[:create])
+      @test_obj = nil
+      return nil
+    end
+
+    @created_id = get_prop(obj, :id)
+    @created_obj = obj
+
+    # Convert to string - for code coverage
+    s = @test_obj.to_s
+
+    expect("to_s\t") { !s.empty? }
+  end
+
+  #-----------------------------------------------------------------------------
+  ##
+  # Test 2 - Get all objects and ensure the newly created object is there
+  def test_get_all()
+    @test_name = "test_#{@obj_name}: get_all:     "
+    @error     = nil
+
+    ok, all_objs = do_test_get_all
+    return if expect("get_all\t") { ok }
+
+    @test_obj = all_objs.find { |o| get_prop(o, :id) == @created_id }
+    return if expect("") { ! @test_obj.nil? }
+
+    verify_against(@prop_sets[:create])
+  end
+
+  def fetch_via(desc, key)
+    ok, @test_obj = do_test_get_one(key)
+    return if expect(desc + "\t") { ok }
+
+    verify_against(@prop_sets[:create])
+  end
+
+  #-----------------------------------------------------------------------------
+  ##
+  # Test 3 - Fetch that object by each of id/key/name
+  def test_key_id_name()
+    base_test_name = "test_#{@obj_name}: get via"
+    @error         = nil
+
+    %i( id name key ).each do | k |
+
+      key = get_prop(@created_obj, k)         # i.e. data item only has ID
+      next if key.nil?
+
+      @test_name = "#{base_test_name} #{k.to_s.upcase}: "
+
+      fetch_via(k.to_s, key)
+    end
+  end
+
+  #-----------------------------------------------------------------------------
+  ##
+  # Test 4 - Update a single property within that object
+  def test_update()
+    @test_name = "test_#{@obj_name}: update:      "
+    @error     = nil
+
+    ok, @test_obj = do_test_update
+    return if expect("") { ok }
+
+    verify_against(@prop_sets[:update])
+  end
+
+  #-----------------------------------------------------------------------------
+  ##
+  # Test 5 - Replace the entire object with another
+  def test_replace()
+    @test_name = "test_#{@obj_name}: replace:     "
+    @error     = nil
+
+    ok, @test_obj = do_test_replace
+    return if expect("") { ok }
+
+    verify_against(@prop_sets[:replace])
+  end
+
+  #-----------------------------------------------------------------------------
+  ##
+  # Test 6 - Delete the object
+  def test_delete()
+    @test_name = "test_#{@obj_name}: delete:      "
+    @error     = nil
+
+    ok, _obj = do_test_delete
+
+    expect("") { ok }
+
+    # Failure case - for code coverage -- delete again should fail
+    ok, _obj = do_test_delete
+    expect("delete deleted") { !ok }
+
+  end
+
+  #-----------------------------------------------------------------------------
+  ##
+  # Test 7 - Verify that it no longer exists
+  def test_deleted()
+    @test_name = "test_#{@obj_name}: deleted:      "
+    @error     = nil
+
+    ok, _obj = do_test_get_one(@created_id)
+
+    expect("") { !ok }
+  end
+
+  #-----------------------------------------------------------------------------
+  ##
+  # Test 8a - Code Coverage specific Feed tests
+  def test_code_coverage_feed()
+    @test_name = "test_code_coverage_#{@obj_name}:"
+    @error     = nil
+
+    do_test_code_coverage_feed
+    expect("") { true }
+  end
+
+  ##
+  # Test 8b - Code Coverage specific Group tests
+  def test_code_coverage_group()
+    @test_name = "test_code_coverage_#{@obj_name}:"
+    @error     = nil
+
+    do_test_code_coverage_group
+    expect("") { true }
+  end
+
+  ##
+  # Test 8c - Code Coverage specific Data tests
+  def test_code_coverage_data
+    @test_name = "test_code_coverage_#{@obj_name}:"
+    @error     = nil
+
+    do_test_code_coverage_data
+    expect("") { true }
+  end
+
+  #-----------------------------------------------------------------------------
+  ##
+  # If an existing object exists, get it - useful (and only used) if debugging
+  #
+  # @return true if found
+  def get_existing()
+    names = if @obj_name == "feeds"
+              TEST_FEED_NAMES
+            else
+              TEST_GROUP_NAMES
+            end
+
+    obj = nil
+    names.each do |n|
+      ok, obj = base_get("#{@obj_path}/#{n}")
+      break if ok
+      obj = nil
+    end
+    return false if obj.nil?
+
+    @created_id = get_prop(obj, :id)
+    @created_obj = obj
+    @test_obj = obj
+    true
+  end
+
+end
+
+################################################################################
+
+##
+# TestObject for testing a Data item
+#   Data requires a feed and hence this is pretty much just a wrapper around
+#     the above TestObject which creates a feed, calls the TestObject#run
+#     method and then deletes the feed.
+#
+class TestDataObject < TestObject
+  def initialize(prop_sets)                               # overrides
+    super(prop_sets)
+    @payload = LIST_OF_PROP_SETS[:feeds][:create]
+  end
+
+  def run()                               # overrides
+    non_test_create_data_feed()
+
+    super
+
+    non_test_delete_data_feed()
+  end
+
+protected
+
+  def test_key_id_name()                  # overrides
+    # Data has only an ID key, so cleaner to just override it.
+    @test_name = "test_#{@obj_name}: get via id\t"
+
+    old = @obj_path
+    @obj_path = "#{@obj_path.sub("_FEEDID_", @feed_id)}/"
+
+    fetch_via("id", @created_id)
+
+    @obj_path = old
+  end
+
+end
+
+################################################################################
+
+##
+# Convenience method to run all the tests for all the objects.
+#
+# This is the (only) entry point to the tests.
+def run_all
+  puts "Setting up.."
+  TestObject.new().ensure_starting_state
+  puts " - done"
+
+  LIST_OF_PROP_SETS.each do |_key, lops|
+
+    begin
+      lops[:ctor].call(lops).run
+      puts ""
+    rescue => e
+      puts "### Exception caught ###"
+      puts e
+      puts e.backtrace
+      puts "### continuing.. ###"
+    end
+  end
+end

--- a/manual_tests/lib/testobjectdata.rb
+++ b/manual_tests/lib/testobjectdata.rb
@@ -1,0 +1,68 @@
+#!/usr/bin/env ruby
+
+##
+# Data for TestObject class
+#
+
+TEST_FEED_NAME_1  = "feed xyzzy"
+TEST_FEED_NAME_2  = "feed foobar"
+TEST_GROUP_NAME_1 = "group xyzzy"
+TEST_GROUP_NAME_2 = "group foobar"
+
+TEST_FEED_NAMES  = [ TEST_FEED_NAME_1,  TEST_FEED_NAME_2  ]
+TEST_GROUP_NAMES = [ TEST_GROUP_NAME_1, TEST_GROUP_NAME_2 ]
+
+##
+# Hash of hashes, each containing information for the API ops with a payload,
+#  including the (parts of the) payload to send.
+#
+LIST_OF_PROP_SETS = {
+  feeds: {
+    name: "feeds",
+    path: "feeds",
+    ctor: ->(ps) { TestObject.new(ps) } ,
+    create: {
+        "name"          => TEST_FEED_NAME_1,
+        "description"   => "feed Xyyzy Foobar",
+    },
+    update: {
+        "description"   => "feed Foobar Xyyzy",
+    },
+    replace: {
+        "name"          => TEST_FEED_NAME_2,
+        "description"   => "Xyyzy Foobar feed",
+    },
+  },
+
+  groups: {
+    name: "groups",
+    path: "groups",
+    ctor: ->(ps) { TestObject.new(ps) } ,
+    create: {
+        "name"          => TEST_GROUP_NAME_1,
+        "description"   => "group Xyyzy Foobar",
+    },
+    update: {
+        "description"   => "group Foobar Xyyzy",
+    },
+    replace: {
+        "name"          => TEST_GROUP_NAME_2,
+        "description"   => "Xyyzy Foobar group",
+    },
+  },
+
+  data: {
+    name: "data",
+    path: "feeds/_FEEDID_/data",      # _FEEDID_ replaced with actual feed id
+    ctor: ->(ps) { TestDataObject.new(ps) } ,
+    create: {
+        "value" => "data xyzzy",
+    },
+    update: {
+        "value" => "data foobar",
+    },
+    replace: {
+        "value" => "xyyzy data",
+    },
+  },
+}

--- a/manual_tests/lib/verify.rb
+++ b/manual_tests/lib/verify.rb
@@ -1,0 +1,120 @@
+#!/usr/bin/env ruby
+
+##
+# Module with verification helpers
+#
+# Handles HTTP REST or ruby library objects
+#
+# If accessing directly via HTTP REST, obj will be a hash
+# otherwise, it's a class from the ruby libray, which has a hash
+#   of all the properties.
+
+module Verify
+
+  ##
+  # Handled expected outcome, including printing PASS/FAIL
+  #
+  # @yield  block containing the actual test, returning a boolean
+  # @return true if failed
+  #
+  def expect(desc)
+    b = yield
+
+    leader = if (desc.nil? || desc.empty?)
+               "#{@test_name}"
+             else
+               "\t\t#{desc}"
+             end
+
+    if b.nil?
+      puts("#{leader}\tSKIP - #{@error}")
+    elsif b
+      puts("#{leader}\tPASS")
+    else
+      puts("#{leader}\tFAIL - #{@error}")
+    end
+
+    !b      # return true on failure
+  end
+
+  ##
+  # Verify that the current object (@test_obj) has the specified properties
+  #   and that the values match.
+  def verify_against(props, list_key = nil)
+    obj = obj_as_hash(@test_obj)
+    return false if obj.nil?
+
+    if list_key.nil?
+      return _verify(obj, props, nil)
+    end
+
+    _verify(obj, props, list_key)
+  end
+
+protected
+
+  ##
+  # If the object is a Hash, return it (HTTP-direct API object).
+  # Otherwise, build a hash from its getters (ruby library API object).
+  def obj_as_hash(obj)
+    return obj        if obj.is_a? Hash
+    return obj.values if obj.respond_to? :values
+
+    h = {}
+    obj.methods(false).each do |m|
+      next if m =~ /=/
+      h[m.to_sym] = obj.send(m)
+    end
+
+    h
+  end
+
+  ##
+  # Get a property from the object, regardless of where it came from.
+  def _get_prop(obj, prop)
+    obj = obj_as_hash(obj)
+    if obj.nil?
+      return nil
+    end
+
+    p = prop.to_sym
+    p = prop.to_s unless obj.has_key?(p)
+    return obj.has_key?(p) ? obj[p] : nil
+  end
+
+  ##
+  # Get a property from the object, regardless of whence it came.
+  def get_prop(obj, prop)
+    val = _get_prop(obj, prop)
+    if val.nil?
+      $stderr.puts "#{@test_name} get_prop (#{prop}): " \
+                                   "FAIL - unknown object: #{obj.inspect}"
+      exit 1
+    end
+
+    val
+  end
+
+protected
+
+  def _verify(obj, against_props, within_internal_list)
+    failed = false
+    against_props.each_pair do |key, expected|
+      actual =  if within_internal_list.nil?
+                  get_prop(obj, key)
+                else
+                  o = obj[within_internal_list].find { |i| i[:name] == key }
+                  get_prop(o, :last_value)
+                end
+
+      if actual != expected
+        fid = @test_obj.has_key?(:id) ? @test_obj[:id] : "unk"
+        puts("\tFAIL (ID: #{fid} - #{key}: #{old} != expected #{expected})")
+        failed = true
+      end
+    end
+
+    expect("each_prop") { !failed }
+  end
+
+end

--- a/manual_tests/test_http.rb
+++ b/manual_tests/test_http.rb
@@ -1,0 +1,12 @@
+#!/usr/bin/env ruby
+
+$LOAD_PATH.unshift "manual_tests/lib"
+
+require 'httpdirectfetch'
+
+class TestObject
+  include HTTPDirectFetch
+end
+
+puts "Test Adafruit IO API via HTTP REST calls"
+run_all

--- a/manual_tests/test_iolib.rb
+++ b/manual_tests/test_iolib.rb
@@ -1,0 +1,34 @@
+#!/usr/bin/env ruby
+
+$LOAD_PATH.unshift "manual_tests/lib"
+
+require 'rubylibfetch'
+
+class TestObject
+  include RubyLibFetch
+end
+
+puts "Test Adafruit IO API via the io-client-ruby library"
+begin
+run_all
+rescue
+end
+
+# For code coverage
+
+print "Code Coverage, part 2a"
+
+# 1   Alternate server URL
+ENV['ADAFRUIT_IO_URL'] = "https://io.adafruit.com"
+AIO2 = Adafruit::IO::Client.new :key => ENV['ADAFRUIT_IO_KEY'].freeze
+AIO2.feeds.retrieve(24601)
+puts "\t\tOK"
+
+print "Code Coverage, part 2b"
+
+# IO::Client#last_response
+AIO2.last_response
+puts "\t\tOK"
+
+puts "ALL DONE"
+exit 0

--- a/spec/README.md
+++ b/spec/README.md
@@ -2,30 +2,14 @@
 
 To run the tests you can use rake from the top level directory.
 
-However, most tests require a valid Adafruit IO account to run, and so an
-account key needs to be provided.  The key is passed to the tests via an
-environment variable called ADAFRUIT_IO_KEY.
+None of these tests require a valid Adafruit IO account to run, and so are
+used as verification via the automated CI service Travis.
 
-So, the tests can be run via the following command:
+The tests can be also run manually via the following command:
 
-    ADAFRUIT_IO_KEY=my_key rake test
+    rake test
 
-Alternatively, you can place the key into a file in the top level directory
-called _.env_.  The format is the same as above, but as a single line and
-by itself. e.g.
+## Manual tests
 
-    # cat .env
-    ADAFRUIT_IO_KEY=my_key
-
-# NOTES
-
-- Take care running the tests that you do not spam the server.  The server has
-throttle checks in place and if you exceed the limit, you will be blocked for
-a period of time. See
-[HTTP 503: Unavailable](https://learn.adafruit.com/adafruit-io/http-status-codes).
-See also [Data Policies](https://learn.adafruit.com/adafruit-io/data-policies).
-
-- Additionally, you must have one feed, one group and one dashboard available
-for creating. (As of this writing, you are allowed only 10, 10, and 5,
-respectively). Again see
-[Data Policies](https://learn.adafruit.com/adafruit-io/data-policies)
+A set of manual tests, which do require an active Adafruit IO account API key
+can be found under manual_tests.  See the Readme there for details.


### PR DESCRIPTION
I created a new suite of manual tests - ones that require an API key, which currently cover almost 90+% of the library code.

- Those that are missed are a couple of methods which fail (one each in `::Data` and `::Client`) and I believe need library changes.
- The bulk are in `::Group`, but I can't find the documentation on them at https://io.adafruit.com/api/docs/#!/Groups (and the deprecated one).
- Ignoring those, there's 100% coverage.

Here's the stats for the missing coverage:

     92.61% Code coverage
     95.12 %  data.rb     - #send_data missed - library issues
     97.78 %  client.rb   - #data      missed - library issues
     67.44 %  group.rb    - only undocumented methods missed
                              #create_group,  #send_group
                              #receive_group, #receive_next_group,
                              #groups(*args) (deprecated)
    
- There's a way to have `SimpleCov` ignore code (by wrapping it with `# :nocov:`).

I'd like to do that, if you don't mind - at least around  the deprecated `Group#groups` method.
I'm not sure about the other group methods - are they from an older version of the API or a future one or just not documented.  (btw, if the latter, then `#receive_previous_group` seems to be missing)